### PR TITLE
Add support for Laravel v8.x

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         php: [7.4]
-        laravel: [7.*, 6.*, 5.8.*]
+        laravel: [8.*, 7.*, 6.*, 5.8.*]
         dependency-version: [prefer-stable]
         include:
           - laravel: 8.*

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,19 +9,17 @@ jobs:
     strategy:
       matrix:
         php: [7.4]
-        laravel: [7.*, 6.*, 5.8.*, 5.7.*, 5.6.*]
+        laravel: [7.*, 6.*, 5.8.*]
         dependency-version: [prefer-stable]
         include:
+          - laravel: 8.*
+            testbench: 6.*
           - laravel: 7.*
             testbench: 5.*
           - laravel: 6.*
             testbench: 4.*
           - laravel: 5.8.*
             testbench: 3.8.*
-          - laravel: 5.7.*
-            testbench: 3.7.*
-          - laravel: 5.6.*
-            testbench: 3.6.*
 
     name: CI - PHP ${{ matrix.php }}  - Laravel ${{ matrix.laravel }} - Testbench ${{ matrix.testbench }} (${{ matrix.dependency-version }})
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `mateusjunges/laravel-invite-codes` will be documented in this file.
 
+## 1.3.0 2020-09-08
+- Add support for laravel v8.x
+- Drop support for Larvel v5.6 and v5.7
+
 ## 1.2.2 2020-11-03
 - Change test suite to run on github actions instead of TravisCi
 

--- a/composer.json
+++ b/composer.json
@@ -13,12 +13,12 @@
     ],
     "require": {
         "php": "^7.4",
-        "illuminate/auth": "^5.6|^5.7|^5.8|^6.0|^7.0",
-        "illuminate/support": "^5.6|^5.7|^5.8|^6.0|^7.0",
-        "illuminate/database": "^5.6|^5.7|^5.8|^6.0|^7.0"
+        "illuminate/auth": "^5.8|^6.0|^7.0|^8.0",
+        "illuminate/support": "^5.8|^6.0|^7.0|^8.0",
+        "illuminate/database": "^5.8|^6.0|^7.0|^8.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^3.6|^3.7|^3.8|^4.0|^5.0",
+        "orchestra/testbench": "^3.8|^4.0|^5.0",
         "phpunit/phpunit": "^7.0|^8.0|^9.0",
         "predis/predis": "^1.1"
     },


### PR DESCRIPTION
- Add support for Laravel v8.x
- Drop support for Laravel v5.6.x
- Drop support for Laravel v5.7.x