### PR TITLE
Bugfix: Use Default Invite Model

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ public function __construct()
     $this->middleware('protected_by_invite_codes');
 }
 ```
+> **Note**
+This middleware expects to find an invitation code within the `invite_code` key of your request. 
 
 ## Creating invite codes
 

--- a/src/Http/Middlewares/ProtectedByInviteCodeMiddleware.php
+++ b/src/Http/Middlewares/ProtectedByInviteCodeMiddleware.php
@@ -32,7 +32,7 @@ class ProtectedByInviteCodeMiddleware
         }
 
         $invite_code = $request->input('invite_code');
-        $invite_model = app(config('invite-codes.models.invite_model') ?? Invite::class);
+        $invite_model = app(config('invite-codes.models.invite_model', Invite::class));
 
         try {
             $invite = $invite_model->where('code', $invite_code)->firstOrFail();

--- a/src/Http/Middlewares/ProtectedByInviteCodeMiddleware.php
+++ b/src/Http/Middlewares/ProtectedByInviteCodeMiddleware.php
@@ -3,6 +3,7 @@
 namespace Junges\InviteCodes\Http\Middlewares;
 
 use Closure;
+use Junges\InviteCodes\Http\Models\Invite;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -31,7 +32,7 @@ class ProtectedByInviteCodeMiddleware
         }
 
         $invite_code = $request->input('invite_code');
-        $invite_model = app(config('invite-codes.models.invite_model'));
+        $invite_model = app(config('invite-codes.models.invite_model') ?? Invite::class);
 
         try {
             $invite = $invite_model->where('code', $invite_code)->firstOrFail();

--- a/src/Http/Middlewares/ProtectedByInviteCodeMiddleware.php
+++ b/src/Http/Middlewares/ProtectedByInviteCodeMiddleware.php
@@ -3,7 +3,6 @@
 namespace Junges\InviteCodes\Http\Middlewares;
 
 use Closure;
-use Junges\InviteCodes\Http\Models\Invite;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
@@ -13,6 +12,7 @@ use Junges\InviteCodes\Exceptions\InviteWithRestrictedUsageException;
 use Junges\InviteCodes\Exceptions\RouteProtectedByInviteCodeException;
 use Junges\InviteCodes\Exceptions\UserLoggedOutException;
 use Junges\InviteCodes\Facades\InviteCodes;
+use Junges\InviteCodes\Http\Models\Invite;
 use Symfony\Component\HttpFoundation\Response;
 
 class ProtectedByInviteCodeMiddleware


### PR DESCRIPTION
I ran into an issue where the `ProtectedByInviteCodeMiddleware.php` was throwing an error because it could not locate the Invite model.  I am using Laravel 10.x and the latest version of this package. 

After some investigation I noticed there was no default value being passed from the call to `config()`.  This was because I had not published the config file using Artisan.  When I published the config file, this error disappeared. 

In order to prevent this, I added a null check + default Invite model inside our `ProtectedByInviteCodeMiddleware.php`

I also updated the ReadMe to include a reference to the exact key within the request where the middleware expects to find the user's invite code.  I found it difficult to locate without code diving. 

Let me know if we would like any other updates for this PR. 

Thanks. 

