### PR TITLE
Drop support for the `canBeUsedXTimes` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ To get started with Laravel Invite Codes, use Composer to add the package to you
 composer require mateusjunges/laravel-invite-codes
 ```
 
-Or add this line in your composer.json, inside of the require section:
+Or add this line in your composer.json, inside the `require` section:
 ```bash
 {
     "require": {
-        "mateusjunges/laravel-invite-codes": "^1.6",
+        "mateusjunges/laravel-invite-codes": "^2.0",
     }
 }
 ```
@@ -195,14 +195,6 @@ To restrict the usage of an invite code you can use the `restrictUsageTo()` meth
 
 If you want that your invite code be used a limited amount of times, you can set the max usages limit with the `maxUsages()` method, and pass an integer with the amount
 of allowed usages.
-
-Also, you can use the declarative syntax, and use the `canBeUsedXTimes()` method, where `X` is the amount of times your invite code will be usable.
-For example:
-
-- `->canBeUsed10Times()`: This invite code can be used 10 times.
-- `->canBeUsed50Times()`: This invite code can be used 50 times.
-
-> You can use any integer number you want with this method.
 
 ## Create multiple invite codes
 

--- a/src/InviteCodes.php
+++ b/src/InviteCodes.php
@@ -29,23 +29,6 @@ class InviteCodes implements InviteCodesContract
     protected ?CarbonInterface $expires_at;
     protected bool $dispatch_events = true;
 
-    /**
-     * @param $arguments
-     *
-     * @throws BadMethodCallException
-     * @throws InviteMustBeAbleToBeRedeemedException
-     */
-    public function __call(string $name, $arguments): self
-    {
-        if (method_exists($this, $name)) {
-            $this->{$name}($arguments);
-        } elseif (preg_match('/^canBeUsed(\d+)Times$/', $name, $max_usages)) {
-            return $this->maxUsages($max_usages[1]);
-        }
-
-        throw new BadMethodCallException('Invalid method called');
-    }
-
     /** If used, no events will be dispatched. */
     public function withoutEvents(): self
     {

--- a/tests/InviteModelMethodsTest.php
+++ b/tests/InviteModelMethodsTest.php
@@ -88,35 +88,4 @@ class InviteModelMethodsTest extends TestCase
 
         $this->assertCount(1, Invite::soldOut()->get());
     }
-
-    public function test_can_be_used_n_times()
-    {
-        $invite = InviteCodes::create()
-            ->canBeUsed2Times()
-            ->save();
-
-        InviteCodes::redeem($invite->code);
-        InviteCodes::redeem($invite->code);
-        $this->assertTrue(true);
-    }
-
-    public function test_cant_be_used_more_than_n_times()
-    {
-        $invite = InviteCodes::create()
-            ->canBeUsed2Times()
-            ->save();
-
-        $this->expectException(SoldOutException::class);
-        InviteCodes::redeem($invite->code);
-        InviteCodes::redeem($invite->code);
-        InviteCodes::redeem($invite->code);
-    }
-
-    public function test_can_be_used_0_times_is_invalid()
-    {
-        $this->expectException(InviteMustBeAbleToBeRedeemedException::class);
-        InviteCodes::create()
-            ->canBeUsed0Times()
-            ->save();
-    }
 }


### PR DESCRIPTION
I just don't like this syntax and don't use it myself, so I don't want to maintain it.