### PR TITLE
Prepare Laravel 13 support and move Pint to require-dev

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,13 +11,15 @@ jobs:
     strategy:
       matrix:
         php: [8.4]
-        laravel: ['11.*', '12.*']
+        laravel: ['11.*', '12.*', '13.*']
         dependency-version: [prefer-stable]
         include:
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     name: CI - PHP ${{ matrix.php }}  - Laravel ${{ matrix.laravel }} - Testbench ${{ matrix.testbench }} (${{ matrix.dependency-version }})
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `mateusjunges/laravel-invite-codes` will be documented in this file.
 
+## [Unreleased]
+
+- Add Laravel 13 support
+- Move `laravel/pint` from production dependencies to `require-dev` (`^1.13`)
+
 ## [v2.3.0 - 2025-09-01](https://github.com/mateusjunges/laravel-invite-codes/compare/v2.2.1...v2.3.0)
 - Drop support for Laravel 10, PHP 8.2 and PHP 8.3 by [@mateusjunges](https://github.com/mateusjunges) in [#46](https://github.com/mateusjunges/laravel-invite-codes/pull/46)
 

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
     ],
     "require": {
         "php": "^8.4",
-        "illuminate/auth": "^11.45|^12.0",
-        "illuminate/support": "^11.45|^12.0",
-        "illuminate/database": "^11.45|^12.0",
-        "laravel/pint": "dev-main"
+        "illuminate/auth": "^11.45|^12.0|^13.0",
+        "illuminate/support": "^11.45|^12.0|^13.0",
+        "illuminate/database": "^11.45|^12.0|^13.0"
     },
     "require-dev": {
-        "orchestra/testbench": "8.0|^10.0",
+        "laravel/pint": "^1.13",
+        "orchestra/testbench": "8.0|^10.0|^11.0",
         "pestphp/pest": "^4.0",
         "pestphp/pest-plugin-laravel": "^4.0",
-        "predis/predis": "^1.1|^2.3",
+        "predis/predis": "^1.1|^2.3|^3.4",
         "rector/rector": "dev-main"
     },
     "minimum-stability": "dev",


### PR DESCRIPTION
## Summary

- Allow `illuminate/auth`, `illuminate/support`, and `illuminate/database` `^13.0` for Laravel 13 prep
- Move `laravel/pint` from `require` to `require-dev` with `^1.13` so it is not pulled into production installs of consuming apps
- Extend `orchestra/testbench` and `predis/predis` constraints for L13-compatible dev tooling
- Add Laravel `13.*` / Testbench `11.*` to the CI matrix

## Motivation

Prepare the package for Laravel 13 without Composer version aliases or a transitive production dependency on Pint.

## Test plan

- [x] `composer update`
- [x] `composer test` (20 tests passing)